### PR TITLE
Add Not Human Search to Agentic search and Search Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ SPLADE – a sparse bi-encoder BERT-based model achieves effective and efficient
 ### Agentic search
 
 - [Agentic Search as an Agile Engineering Process](https://dtunkelang.medium.com/agentic-search-as-an-agile-engineering-process-5514b0790e8e)
+- [Not Human Search](https://nothumansearch.ai/) - Search engine built for AI agents, indexing 1,400+ agent-first tools and APIs. Offers MCP server, REST API, and llms.txt for machine-readable discovery.
 
 ## Search Quality Assurance
 
@@ -907,6 +908,7 @@ Synonyms: autocomplete, search as you type, suggestions
 
 * Google
 * Bing
+* [Not Human Search](https://nothumansearch.ai/) - Agent-first search engine for discovering AI tools and MCP servers
 * Yandex
 * Amazon
 * eBay


### PR DESCRIPTION
## Summary

Adds [Not Human Search](https://nothumansearch.ai/) to two sections:

- **Agentic search** — NHS is a search engine specifically designed for AI agents, fitting directly into this emerging category. It indexes 1,400+ agent-first tools and APIs with structured metadata (MCP support, auth type, API availability) and exposes results via REST API, MCP server, and llms.txt.

- **Search Engines** — Listed alphabetically among existing entries (Google, Bing, Yandex, etc.) as a specialized search engine focused on agent tool discovery rather than general web content.

### Why it fits

The "Agentic search" section currently has one entry (Daniel Tunkelang's essay on the concept). NHS is a working implementation of agentic search — a search engine where the primary consumers are AI agents, not humans. Results are returned as structured JSON, ranked by agent-relevant signals (API availability, MCP compliance, documentation completeness), and accessible via machine-native protocols.