### PR TITLE
Add SearchPixel - hybrid CLIP+BGE product search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,7 +933,7 @@ Synonyms: autocomplete, search as you type, suggestions
 * [Qdrant](https://qdrant.tech/) - an open source vector database.
 * [Awakari](https://awakari.com) - Real-Time search from unlimited sources like RSS, Fediverse, Telegram. Text keyword matching conditions, numeric conditions, condition groups. Reverse search index based.
 * [Meilisearch](https://www.github.com/meilisearch/meilisearch) - Open source search API that supports full-text, vector, geospatial & faceted search.
-* [SearchPixel](https://searchpixel.pixelapi.dev) - Hybrid CLIP + BGE product search API for Shopify / WooCommerce. Visual + semantic, INR pricing, free in beta for first 50 stores.
+* [SearchPixel](https://searchpixel.pixelapi.dev) - Hybrid CLIP + BGE product-search API for Shopify and WooCommerce stores. Combines visual and semantic search, priced in INR (Indian rupees), and free during the open beta for the first 50 stores.
 
 ### Consulting companies
 

--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@ Synonyms: autocomplete, search as you type, suggestions
 * [Qdrant](https://qdrant.tech/) - an open source vector database.
 * [Awakari](https://awakari.com) - Real-Time search from unlimited sources like RSS, Fediverse, Telegram. Text keyword matching conditions, numeric conditions, condition groups. Reverse search index based.
 * [Meilisearch](https://www.github.com/meilisearch/meilisearch) - Open source search API that supports full-text, vector, geospatial & faceted search.
+* [SearchPixel](https://searchpixel.pixelapi.dev) - Hybrid CLIP + BGE product search API for Shopify / WooCommerce. Visual + semantic, INR pricing, free in beta for first 50 stores.
 
 ### Consulting companies
 


### PR DESCRIPTION
Adding SearchPixel under **Products and services**. It is a hybrid CLIP ViT-L/14 + BGE base product search API targeted at Shopify / WooCommerce stores - visual search and semantic search over the same catalog.

Engineering writeup: https://pixelapi.dev/blog/searchpixel-launch.html

Open beta - free for the first 50 stores. Happy to adjust placement or phrasing.