### PR TITLE
add DocKit to Tools > Other section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,7 @@ Synonyms: autocomplete, search as you type, suggestions
 ### Other
 
 * [Chorus](https://github.com/querqy/chorus), [Smui](https://github.com/querqy/smui), [Querqy](https://github.com/querqy/querqy)
+* [DocKit](https://geekfun.club/products/dockit/) - Desktop GUI client for Elasticsearch, OpenSearch, and DynamoDB with AI-powered query generation
 * [Quepid](https://github.com/o19s/quepid)
 * [Rated Ranking Evaluator](https://github.com/SeaseLtd/rated-ranking-evaluator)
 * [Jina AI](https://github.com/jina-ai/jina) - A neural search framework

--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ Synonyms: autocomplete, search as you type, suggestions
 ### Other
 
 * [Chorus](https://github.com/querqy/chorus), [Smui](https://github.com/querqy/smui), [Querqy](https://github.com/querqy/querqy)
-* [DocKit](https://geekfun.club/products/dockit/) - Desktop GUI client for Elasticsearch, OpenSearch, and DynamoDB with AI-powered query generation
+* [DocKit](https://www.geekfun.club/products/dockit/) - Desktop GUI client for Elasticsearch, OpenSearch, and DynamoDB with AI-powered query generation
 * [Quepid](https://github.com/o19s/quepid)
 * [Rated Ranking Evaluator](https://github.com/SeaseLtd/rated-ranking-evaluator)
 * [Jina AI](https://github.com/jina-ai/jina) - A neural search framework


### PR DESCRIPTION
## Summary

Add DocKit to the Tools > Other section.

DocKit is an open-source desktop GUI client for Elasticsearch, OpenSearch, and DynamoDB with AI-powered query generation. It runs on macOS, Windows, and Linux (latest release v0.9.10, Apr 2026, 1k+ GitHub stars).

- Desktop GUI for Elasticsearch/OpenSearch/DynamoDB
- Built-in AI assistant for natural language queries
- Free and open source