### PR TITLE
Add Mydentify as a software discovery platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,7 @@ Synonyms: autocomplete, search as you type, suggestions
 * Google
 * Bing
 * [Not Human Search](https://nothumansearch.ai/) - Agent-first search engine for discovering AI tools and MCP servers
+* [Mydentify](https://mydentify.com/) - Intent-led search engine for discovering and comparing software from structured, source-backed product evidence
 * Amazon
 * eBay
 

--- a/obsidian/vault/Awesome Search/Companies/Mydentify.md
+++ b/obsidian/vault/Awesome Search/Companies/Mydentify.md
@@ -1,0 +1,23 @@
+---
+type: company
+tags: [company, vertical-search, product-discovery, software-discovery]
+category: technology-provider
+industry: software-discovery
+products: [Mydentify]
+search_domain: [software discovery, intent-based search, product comparison]
+use_cases: [goal-based software discovery, evidence-backed product comparison]
+people: []
+created: 2026-08-12
+---
+
+# Mydentify
+
+[Mydentify](https://mydentify.com/) is an intent-led software discovery and comparison platform. It maps a user's stated goal to relevant products, then presents structured product facts and source-backed evidence for comparison.
+
+## Search Approach
+
+- **Intent before category** — users can describe the job they need to complete instead of beginning with a fixed software category.
+- **Structured product evidence** — results organize product facts and supporting sources so users can inspect why a product matches.
+- **Public discovery surfaces** — no-key product and intent feeds make the catalog available to developers and software agents as well as human searchers.
+
+Mydentify is a vertical discovery product rather than a general-purpose search backend. Its search domain is software selection, where query intent and verifiable product attributes are more useful than lexical similarity alone.

--- a/obsidian/vault/Awesome Search/Topics/Search Platforms.md
+++ b/obsidian/vault/Awesome Search/Topics/Search Platforms.md
@@ -82,6 +82,7 @@ Some platforms are not general-purpose search engines but focus on a specific do
 
 - **[[searchHub]]** ([[Andreas Wagner]]) — e-commerce-focused SaaS platform for search optimization and query understanding. Covers query rewriting, A/B testing, analytics, and spell correction (SmartQuery). Also released the Open Commerce Search Stack (OCSS) as an open-source reference implementation for retail search. See [[Three Pillars of Search Quality - Findability]] and [[Common Pitfalls of Onsite Search Experimentation]].
 - **[[Hornet]]** ([[Jo Kristian Bergum]], [[Lester Solbakken]]) — retrieval infrastructure platform purpose-built for AI agents. Focuses on high-precision context delivery for agentic workloads, where query patterns differ fundamentally from human search (longer queries, web-search operators, multi-turn compounding). See [[This Is What Agentic Retrieval Looks Like]] and [[Mutually Assured Distraction]].
+- **[[Mydentify]]** — intent-led software discovery and comparison platform. It maps goal descriptions to products and organizes structured, source-backed product evidence; it is a vertical discovery product rather than a general-purpose search backend.
 - **Empathy.co** — e-commerce search and discovery platform; SaaS, focused on search UX, analytics, and personalization.
 - **Constructor.io** — SaaS product discovery platform for e-commerce; combines search, recommendations, and browse with ML-driven ranking.
 


### PR DESCRIPTION
## Summary

- add a focused Mydentify company note to the current Obsidian vault
- connect it from the Specialized / Vertical Platforms section
- describe the intent-led software-discovery scope without presenting it as a general-purpose search backend

## Verification

- https://mydentify.com/ returns HTTP 200
- the company wikilink resolves to `Companies/Mydentify.md`
- `git diff --check` passes

## Disclosure

I maintain Mydentify. This contribution is limited to factual product scope and does not request a reciprocal link or engagement.